### PR TITLE
Use Windows Selector event loop policy for asyncio

### DIFF
--- a/start_server.py
+++ b/start_server.py
@@ -112,6 +112,8 @@ def _pre_launch_checks():
 def main():
     server = None
 
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 


### PR DESCRIPTION
There's an issue atm where for servers hosted on Windows, some abnormal ways in which a client may disconnect may lead to an asyncio ConnectionResetError. This is because the default event loop policy used on Windows, `[ProactorEventLoop](https://docs.python.org/3.14/library/asyncio-eventloop.html#asyncio.ProactorEventLoop)`, does not handle some odd cases in which the socket disconnects on the other side, server would like to close the socket, but the socket is already closed. It's effectively an odd race.

This PR makes it so that the asyncio event loop policy for Windows is now [WindowsSelectorEventLoopPolicy](https://docs.python.org/3.14/library/asyncio-policy.html#asyncio.WindowsSelectorEventLoopPolicy), which should not have this issue.

This implementation will have issues in Python 3.16 (which should come out in 2027), because they'd be dropping being able to set event loop policies. I believe when that comes out, an effective implementation would be just to swallow the `ConnectionResetError` in the custom exception handler. However, the asyncio ProactorEventLoop issue may be fixed by then, so 🤷 